### PR TITLE
feat: 支持连接阿里云 OSS

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -160,7 +160,11 @@ public partial class App : Application
         services.AddSingleton<Platforms.MacCatalyst.Services.MacFileService>(sp => new Platforms.MacCatalyst.Services.MacFileService(sp.GetRequiredService<SqliteFileIndex>()));
         services.AddSingleton<IRemoteConnectionService, Services.Impl.RemoteConnectionService>();
         services.AddSingleton<SftpFileService>();
-        services.AddSingleton<IRemoteFileService>(sp => sp.GetRequiredService<SftpFileService>());
+        services.AddSingleton<OssFileService>();
+        services.AddSingleton<IRemoteFileService>(sp => new Services.Impl.RemoteFileServiceRouter(
+            sp.GetRequiredService<IRemoteConnectionService>(),
+            sp.GetRequiredService<SftpFileService>(),
+            sp.GetRequiredService<OssFileService>()));
         services.AddSingleton<IRemoteFileEditService, Services.Impl.RemoteFileEditService>();
         services.AddSingleton<IFileService>(sp => new CompositeFileService(
             sp.GetRequiredService<Platforms.MacCatalyst.Services.MacFileService>(),

--- a/MacExplorer.csproj
+++ b/MacExplorer.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Svg.Skia" Version="5.0.0" />
     <PackageReference Include="SSH.NET" Version="2025.0.0" />
+    <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.14.1" />
   </ItemGroup>
 
   <!-- Create macOS .app bundle after build (macOS-only: Avalonia Desktop outputs a raw binary, not a bundle) -->

--- a/Models/RemoteServerInfo.cs
+++ b/Models/RemoteServerInfo.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 namespace MacExplorer.Models;
 
@@ -9,6 +10,7 @@ public class RemoteServerInfo : INotifyPropertyChanged
 
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
     public string Name { get; set; } = "";
+    public RemoteProtocol Protocol { get; set; } = RemoteProtocol.Sftp;
     public string Host { get; set; } = "";
     public int Port { get; set; } = 22;
     public string Username { get; set; } = "";
@@ -17,8 +19,26 @@ public class RemoteServerInfo : INotifyPropertyChanged
     public string PrivateKeyPath { get; set; } = "";
     public string DefaultPath { get; set; } = "/";
 
-    public string DisplayName => string.IsNullOrWhiteSpace(Name) ? $"{Username}@{Host}" : Name;
-    public string ConnectionString => $"{Username}@{Host}:{Port}";
+    // Aliyun OSS
+    /// <summary>OSS endpoint, e.g. oss-cn-hangzhou.aliyuncs.com</summary>
+    public string Endpoint { get; set; } = "";
+    public string Bucket { get; set; } = "";
+    public string AccessKeyId { get; set; } = "";
+    public string AccessKeySecret { get; set; } = "";
+
+    [JsonIgnore]
+    public bool IsOss => Protocol == RemoteProtocol.AliyunOss;
+
+    public string DisplayName
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(Name)) return Name;
+            return IsOss ? Bucket : $"{Username}@{Host}";
+        }
+    }
+
+    public string ConnectionString => IsOss ? $"{Bucket} · {Endpoint}" : $"{Username}@{Host}:{Port}";
 
     public bool IsConnected
     {
@@ -50,4 +70,14 @@ public enum RemoteAuthMethod
 {
     Password,
     PrivateKey
+}
+
+/// <summary>
+/// Remote backend protocol. Sftp is 0 so servers saved before OSS support
+/// keep deserializing as SFTP.
+/// </summary>
+public enum RemoteProtocol
+{
+    Sftp = 0,
+    AliyunOss = 1
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <details open>
 <summary><b>中文</b></summary>
 
-Mac Explorer 是为 macOS 打造的现代文件管理器。它把本地浏览、全文搜索、AI 图片理解、SFTP 远程管理、压缩解压、Git 状态和 Quick Look 整合进一个优雅高效的工作台。
+Mac Explorer 是为 macOS 打造的现代文件管理器。它把本地浏览、全文搜索、AI 图片理解、SFTP / 阿里云 OSS 远程管理、压缩解压、Git 状态和 Quick Look 整合进一个优雅高效的工作台。
 
 ## 为什么选 Mac Explorer
 
@@ -32,6 +32,7 @@ macOS Finder 够用，但不够好用。Mac Explorer 补上了 Windows 文件管
 | 🤖 **AI 图片分析** | Apple Vision 本地识别面孔、场景、地点，完全离线 |
 | ⎇ **Git 状态标记** | 文件图标叠加 Git 状态——新增/修改/未跟踪一目了然 |
 | 🌐 **SFTP 远程管理** | SSH.NET 安全连接，像操作本地文件一样管理远程服务器 |
+| ☁️ **阿里云 OSS** | 填 Endpoint / Bucket / AccessKey 即可挂载 Bucket，浏览、上传、下载、改名一应俱全 |
 | 📦 **压缩解压** | ZIP/TAR/GZ/7Z，内浏览免解压，分卷 + 密码保护 |
 | 👁️ **Quick Look** | 空格键快速预览图片、文档、视频 |
 | ⭐ **文件评分** | 1–5 星评分，持久化存储，支持按评分排序 |
@@ -53,7 +54,7 @@ macOS Finder 够用，但不够好用。Mac Explorer 补上了 Windows 文件管
 <details>
 <summary><b>English</b></summary>
 
-Mac Explorer is a modern file manager built for macOS. It combines local browsing, full-text search, AI-powered image understanding, SFTP remote access, archive management, Git status, and Quick Look into one elegant, efficient workspace.
+Mac Explorer is a modern file manager built for macOS. It combines local browsing, full-text search, AI-powered image understanding, SFTP and Aliyun OSS remote access, archive management, Git status, and Quick Look into one elegant, efficient workspace.
 
 ## Why Mac Explorer
 
@@ -68,6 +69,7 @@ macOS Finder works, but it could be better. Mac Explorer brings the capabilities
 | 🤖 **AI Image Analysis** | On-device Apple Vision for face, scene, and landmark recognition — fully offline |
 | ⎇ **Git Status** | File icon overlays for Git status — added/modified/untracked at a glance |
 | 🌐 **SFTP Remote** | SSH.NET secure connections, manage remote servers like local folders |
+| ☁️ **Aliyun OSS** | Mount a bucket with endpoint / bucket / AccessKey — browse, upload, download, rename |
 | 📦 **Archives** | ZIP/TAR/GZ/7Z, browse without extracting, multi-volume + password protection |
 | 👁️ **Quick Look** | Press Space to preview images, documents, and video instantly |
 | ⭐ **File Rating** | 1–5 star ratings, persistent storage, sort by rating |
@@ -98,6 +100,7 @@ No .NET runtime required — 129 MB self-contained, native Apple Silicon.
 | Microsoft.Data.Sqlite | SQLite FTS5 全文索引 · Full-Text Index |
 | SharpCompress | 压缩解压 · Archive Handling |
 | SSH.NET | SFTP 远程 · Remote File Access |
+| Aliyun.OSS.SDK.NetCore | 阿里云 OSS · Object Storage |
 | Svg.Skia | SVG 图标渲染 · Icon Rendering |
 | Apple Vision | AI 图像分析 · Image Analysis |
 

--- a/Services/CompositeFileService.cs
+++ b/Services/CompositeFileService.cs
@@ -90,10 +90,7 @@ public class CompositeFileService : IFileService
         if (!srcIsRemote && dstIsRemote)
         {
             // Local → Remote: upload with progress
-            var (_, remoteDest) = VirtualPath.ParseRemotePath(destinationDirectory);
-            var remoteClient = _remoteService.GetConnectedClient();
-            if (remoteClient == null) throw new InvalidOperationException("Remote server not connected");
-
+            var (destServerId, remoteDest) = VirtualPath.ParseRemotePath(destinationDirectory);
             var remoteFilePath = remoteDest.TrimEnd('/') + "/" + fileName;
             var fileSize = new FileInfo(sourcePath).Length;
             var label = $"上传 {fileName}";
@@ -101,11 +98,12 @@ public class CompositeFileService : IFileService
 
             try
             {
+                var remoteStream = await _remoteService.OpenWriteAsync(destServerId, remoteFilePath);
                 await Task.Run(() =>
                 {
-                    using var localStream = File.OpenRead(sourcePath);
-                    using var remoteStream = remoteClient.OpenWrite(remoteFilePath);
-                    CopyWithProgress(localStream, remoteStream, fileSize, task);
+                    using (remoteStream)
+                    using (var localStream = File.OpenRead(sourcePath))
+                        CopyWithProgress(localStream, remoteStream, fileSize, task);
                 });
 
                 if (task != null)
@@ -122,21 +120,19 @@ public class CompositeFileService : IFileService
 
         // Remote → Local: download with progress
         var (serverId, remoteSrc) = VirtualPath.ParseRemotePath(sourcePath);
-        var client = _remoteService.GetConnectedClient();
-        if (client == null) throw new InvalidOperationException("Remote server not connected");
-
         var localDestPath = Path.Combine(destinationDirectory, fileName);
-        var dlFileSize = GetRemoteFileSize(client, remoteSrc);
+        var dlFileSize = await _remoteService.GetFileSizeAsync(serverId, remoteSrc);
         var dlLabel = $"下载 {fileName}";
         var dlTask = _taskManager?.AddTask(dlLabel);
 
         try
         {
+            var sourceStream = await _remoteService.OpenReadAsync(serverId, remoteSrc);
             await Task.Run(() =>
             {
-                using var remoteStream = client.OpenRead(remoteSrc);
-                using var localStream = File.Create(localDestPath);
-                CopyWithProgress(remoteStream, localStream, dlFileSize, dlTask);
+                using (sourceStream)
+                using (var localStream = File.Create(localDestPath))
+                    CopyWithProgress(sourceStream, localStream, dlFileSize, dlTask);
             });
 
             if (dlTask != null)
@@ -147,18 +143,6 @@ public class CompositeFileService : IFileService
             if (dlTask != null)
                 _taskManager?.FailTask(dlTask.Id, ex.Message);
             throw;
-        }
-    }
-
-    private static long GetRemoteFileSize(Renci.SshNet.SftpClient client, string remotePath)
-    {
-        try
-        {
-            return client.GetAttributes(remotePath)?.Size ?? 0;
-        }
-        catch
-        {
-            return 0;
         }
     }
 

--- a/Services/IRemoteConnectionService.cs
+++ b/Services/IRemoteConnectionService.cs
@@ -5,12 +5,18 @@ namespace MacExplorer.Services;
 
 public interface IRemoteConnectionService
 {
-    Task<SftpClient> GetOrConnectAsync(RemoteServerInfo server, CancellationToken ct = default);
-    Task<SftpClient> ConnectAsync(RemoteServerInfo server, CancellationToken ct = default);
+    Task GetOrConnectAsync(RemoteServerInfo server, CancellationToken ct = default);
+    Task ConnectAsync(RemoteServerInfo server, CancellationToken ct = default);
     void Disconnect(string serverId);
     void DisconnectAll();
     bool IsConnected(string serverId);
-    SftpClient? GetClient(string serverId);
+
+    /// <summary>The saved/connected server descriptor, used to resolve its protocol and credentials.</summary>
+    RemoteServerInfo? GetServer(string serverId);
+
+    /// <summary>The live SFTP session, or null when the server is not connected or is not an SFTP server.</summary>
+    SftpClient? GetSftpClient(string serverId);
+
     IReadOnlyList<RemoteServerInfo> GetSavedServers();
     void SaveServer(RemoteServerInfo server);
     void RemoveServer(string serverId);

--- a/Services/IRemoteFileService.cs
+++ b/Services/IRemoteFileService.cs
@@ -1,9 +1,19 @@
-using Renci.SshNet;
-
 namespace MacExplorer.Services;
 
+/// <summary>
+/// A remote file backend (SFTP, Aliyun OSS, ...). Transfer is expressed as plain
+/// streams so callers stay protocol-agnostic.
+/// </summary>
 public interface IRemoteFileService : IFileService
 {
     void SetCurrentServer(string serverId);
-    SftpClient? GetConnectedClient();
+
+    /// <summary>Opens a read-only stream over a remote file. The stream may be forward-only.</summary>
+    Task<Stream> OpenReadAsync(string serverId, string remotePath, CancellationToken cancellationToken = default);
+
+    /// <summary>Opens a write stream; the remote file is committed when the stream is disposed.</summary>
+    Task<Stream> OpenWriteAsync(string serverId, string remotePath, CancellationToken cancellationToken = default);
+
+    /// <summary>Size in bytes, or 0 when it cannot be determined.</summary>
+    Task<long> GetFileSizeAsync(string serverId, string remotePath, CancellationToken cancellationToken = default);
 }

--- a/Services/Impl/OssClientFactory.cs
+++ b/Services/Impl/OssClientFactory.cs
@@ -34,22 +34,84 @@ internal static class OssClientFactory
 
     /// <summary>
     /// Accepts what users actually paste — "oss-cn-hangzhou.aliyuncs.com",
-    /// "https://oss-cn-hangzhou.aliyuncs.com", or a bucket-prefixed endpoint —
-    /// and returns the bare region endpoint the SDK expects.
+    /// "https://oss-cn-hangzhou.aliyuncs.com", or the bucket-prefixed host the OSS
+    /// console shows ("my-bucket.oss-cn-hangzhou.aliyuncs.com") — and returns the
+    /// bare region endpoint the SDK expects.
     /// </summary>
     internal static string NormalizeEndpoint(string? endpoint)
     {
-        var value = (endpoint ?? string.Empty).Trim();
+        var value = StripSchemeAndPath(endpoint);
         if (value.Length == 0) return string.Empty;
 
-        if (value.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-            value = value["https://".Length..];
-        else if (value.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
-            value = value["http://".Length..];
+        value = value.TrimEnd('.');
 
-        var slash = value.IndexOf('/');
-        if (slash >= 0) value = value[..slash];
+        // "my-bucket.oss-cn-hangzhou.aliyuncs.com" → "oss-cn-hangzhou.aliyuncs.com".
+        var dot = value.IndexOf('.');
+        if (dot > 0 && !value.StartsWith("oss-", StringComparison.OrdinalIgnoreCase))
+        {
+            var rest = value[(dot + 1)..];
+            if (rest.StartsWith("oss-", StringComparison.OrdinalIgnoreCase))
+                return rest;
+        }
 
-        return value.TrimEnd('.');
+        return value;
+    }
+
+    /// <summary>
+    /// The console shows a bucket as "my-bucket.oss-cn-hangzhou.aliyuncs.com" and
+    /// its overview page as "oss://my-bucket/", but a bucket name can never contain
+    /// a dot — so anything from the first dot on is an endpoint suffix, not the name.
+    /// </summary>
+    internal static string NormalizeBucket(string? bucket)
+    {
+        var value = StripSchemeAndPath(bucket);
+        if (value.Length == 0) return string.Empty;
+
+        var dot = value.IndexOf('.');
+        return dot < 0 ? value : value[..dot];
+    }
+
+    /// <summary>
+    /// Turns whatever identifies a starting folder into a bucket-relative path.
+    /// "oss://my-bucket/photos" and "photos" both become "/photos"; empty becomes "/".
+    /// </summary>
+    internal static string NormalizeDefaultPath(string? path, string? bucket)
+    {
+        var value = (path ?? string.Empty).Trim();
+        if (value.Length == 0) return "/";
+
+        var hadOssScheme = value.StartsWith("oss://", StringComparison.OrdinalIgnoreCase);
+        if (hadOssScheme) value = value["oss://".Length..];
+
+        if (hadOssScheme)
+        {
+            // Drop the leading bucket segment that the oss:// form carries.
+            var bucketName = NormalizeBucket(bucket);
+            var slash = value.IndexOf('/');
+            var firstSegment = slash < 0 ? value : value[..slash];
+            if (bucketName.Length > 0 && string.Equals(firstSegment, bucketName, StringComparison.Ordinal))
+                value = slash < 0 ? string.Empty : value[(slash + 1)..];
+        }
+
+        value = value.Replace('\\', '/').Trim('/');
+        return value.Length == 0 ? "/" : "/" + value;
+    }
+
+    private static string StripSchemeAndPath(string? value)
+    {
+        var result = (value ?? string.Empty).Trim();
+        if (result.Length == 0) return string.Empty;
+
+        foreach (var scheme in (string[])["https://", "http://", "oss://"])
+        {
+            if (!result.StartsWith(scheme, StringComparison.OrdinalIgnoreCase)) continue;
+            result = result[scheme.Length..];
+            break;
+        }
+
+        var slash = result.IndexOf('/');
+        if (slash >= 0) result = result[..slash];
+
+        return result.Trim();
     }
 }

--- a/Services/Impl/OssClientFactory.cs
+++ b/Services/Impl/OssClientFactory.cs
@@ -1,0 +1,55 @@
+using Aliyun.OSS;
+using Aliyun.OSS.Common;
+using MacExplorer.Models;
+
+namespace MacExplorer.Services.Impl;
+
+/// <summary>
+/// Builds <see cref="OssClient"/> instances from a saved server descriptor.
+/// OSS has no persistent session — a client is just a signed HTTP caller — so this
+/// stays a plain factory instead of living in the connection pool.
+/// </summary>
+internal static class OssClientFactory
+{
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(60);
+
+    public static OssClient Create(RemoteServerInfo server)
+    {
+        var endpoint = NormalizeEndpoint(server.Endpoint);
+        if (endpoint.Length == 0)
+            throw new InvalidOperationException("OSS Endpoint 不能为空");
+        if (string.IsNullOrWhiteSpace(server.AccessKeyId) || string.IsNullOrWhiteSpace(server.AccessKeySecret))
+            throw new InvalidOperationException("OSS AccessKeyId / AccessKeySecret 不能为空");
+        if (string.IsNullOrWhiteSpace(server.Bucket))
+            throw new InvalidOperationException("OSS Bucket 不能为空");
+
+        var config = new ClientConfiguration
+        {
+            ConnectionTimeout = (int)RequestTimeout.TotalMilliseconds,
+            MaxErrorRetry = 3
+        };
+
+        return new OssClient(endpoint, server.AccessKeyId.Trim(), server.AccessKeySecret.Trim(), config);
+    }
+
+    /// <summary>
+    /// Accepts what users actually paste — "oss-cn-hangzhou.aliyuncs.com",
+    /// "https://oss-cn-hangzhou.aliyuncs.com", or a bucket-prefixed endpoint —
+    /// and returns the bare region endpoint the SDK expects.
+    /// </summary>
+    internal static string NormalizeEndpoint(string? endpoint)
+    {
+        var value = (endpoint ?? string.Empty).Trim();
+        if (value.Length == 0) return string.Empty;
+
+        if (value.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            value = value["https://".Length..];
+        else if (value.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            value = value["http://".Length..];
+
+        var slash = value.IndexOf('/');
+        if (slash >= 0) value = value[..slash];
+
+        return value.TrimEnd('.');
+    }
+}

--- a/Services/Impl/RemoteConnectionService.cs
+++ b/Services/Impl/RemoteConnectionService.cs
@@ -8,6 +8,7 @@ namespace MacExplorer.Services.Impl;
 public class RemoteConnectionService : IRemoteConnectionService, IDisposable
 {
     private readonly Dictionary<string, SftpClient> _connections = new();
+    private readonly HashSet<string> _ossConnections = new(StringComparer.Ordinal);
     private readonly Dictionary<string, RemoteServerInfo> _servers = new();
     private readonly Dictionary<string, CancellationTokenSource> _reconnectTokens = new();
     private readonly string _configPath;
@@ -29,9 +30,15 @@ public class RemoteConnectionService : IRemoteConnectionService, IDisposable
         LoadSavedServers();
     }
 
-    public async Task<SftpClient> ConnectAsync(RemoteServerInfo server, CancellationToken ct = default)
+    public async Task ConnectAsync(RemoteServerInfo server, CancellationToken ct = default)
     {
         Disconnect(server.Id);
+
+        if (server.IsOss)
+        {
+            await ConnectOssAsync(server, ct);
+            return;
+        }
 
         var client = CreateSftpClient(server);
 
@@ -44,15 +51,34 @@ public class RemoteConnectionService : IRemoteConnectionService, IDisposable
         RegisterConnection(server, client);
 
         _logger?.LogInformation("Connected to {Server}", server.DisplayName);
-        return client;
     }
 
-    public async Task<SftpClient> GetOrConnectAsync(RemoteServerInfo server, CancellationToken ct = default)
+    public async Task GetOrConnectAsync(RemoteServerInfo server, CancellationToken ct = default)
     {
-        if (_connections.TryGetValue(server.Id, out var existing) && existing.IsConnected)
-            return existing;
+        if (IsConnected(server.Id)) return;
+        await ConnectAsync(server, ct);
+    }
 
-        return await ConnectAsync(server, ct);
+    /// <summary>
+    /// OSS is stateless HTTP, so "connecting" means proving the credentials can
+    /// reach the bucket — that is what makes a bad key fail in the dialog rather
+    /// than silently on the first listing.
+    /// </summary>
+    private async Task ConnectOssAsync(RemoteServerInfo server, CancellationToken ct)
+    {
+        await Task.Run(() =>
+        {
+            ct.ThrowIfCancellationRequested();
+            var client = OssClientFactory.Create(server);
+            if (!client.DoesBucketExist(server.Bucket))
+                throw new InvalidOperationException($"Bucket 不存在或无访问权限：{server.Bucket}");
+        }, ct);
+
+        _ossConnections.Add(server.Id);
+        _servers[server.Id] = server;
+        server.IsConnected = true;
+
+        _logger?.LogInformation("Connected to OSS bucket {Bucket}", server.Bucket);
     }
 
     public void Disconnect(string serverId)
@@ -75,6 +101,7 @@ public class RemoteConnectionService : IRemoteConnectionService, IDisposable
             catch { }
             _connections.Remove(serverId);
         }
+        _ossConnections.Remove(serverId);
         if (_servers.TryGetValue(serverId, out var server))
         {
             server.IsConnected = false;
@@ -83,16 +110,20 @@ public class RemoteConnectionService : IRemoteConnectionService, IDisposable
 
     public void DisconnectAll()
     {
-        foreach (var id in _connections.Keys.ToList())
+        foreach (var id in _connections.Keys.Concat(_ossConnections).Distinct().ToList())
             Disconnect(id);
     }
 
     public bool IsConnected(string serverId)
     {
+        if (_ossConnections.Contains(serverId)) return true;
         return _connections.TryGetValue(serverId, out var client) && client.IsConnected;
     }
 
-    public SftpClient? GetClient(string serverId)
+    public RemoteServerInfo? GetServer(string serverId)
+        => _servers.TryGetValue(serverId, out var server) ? server : null;
+
+    public SftpClient? GetSftpClient(string serverId)
     {
         return _connections.TryGetValue(serverId, out var client) && client.IsConnected ? client : null;
     }

--- a/Services/Impl/RemoteConnectionService.cs
+++ b/Services/Impl/RemoteConnectionService.cs
@@ -66,6 +66,11 @@ public class RemoteConnectionService : IRemoteConnectionService, IDisposable
     /// </summary>
     private async Task ConnectOssAsync(RemoteServerInfo server, CancellationToken ct)
     {
+        // Normalise here too, so servers saved before this ran still connect.
+        server.Endpoint = OssClientFactory.NormalizeEndpoint(server.Endpoint);
+        server.Bucket = OssClientFactory.NormalizeBucket(server.Bucket);
+        server.DefaultPath = OssClientFactory.NormalizeDefaultPath(server.DefaultPath, server.Bucket);
+
         await Task.Run(() =>
         {
             ct.ThrowIfCancellationRequested();

--- a/Services/Impl/RemoteFileEditService.cs
+++ b/Services/Impl/RemoteFileEditService.cs
@@ -4,7 +4,7 @@ namespace MacExplorer.Services.Impl;
 
 public class RemoteFileEditService : IRemoteFileEditService, IDisposable
 {
-    private readonly IRemoteConnectionService _connectionService;
+    private readonly IRemoteFileService _remoteFileService;
     private readonly ILogger<RemoteFileEditService>? _logger;
     private readonly string _tempDir;
     private readonly Dictionary<string, FileSystemWatcher> _watchers = new();
@@ -13,9 +13,9 @@ public class RemoteFileEditService : IRemoteFileEditService, IDisposable
     private readonly HashSet<string> _downloading = new();
     private readonly HashSet<string> _uploading = new();
 
-    public RemoteFileEditService(IRemoteConnectionService connectionService, ILogger<RemoteFileEditService>? logger = null)
+    public RemoteFileEditService(IRemoteFileService remoteFileService, ILogger<RemoteFileEditService>? logger = null)
     {
-        _connectionService = connectionService;
+        _remoteFileService = remoteFileService;
         _logger = logger;
         _tempDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -29,9 +29,6 @@ public class RemoteFileEditService : IRemoteFileEditService, IDisposable
 
     public async Task<string> DownloadForEditAsync(string remotePath, string serverId)
     {
-        var client = _connectionService.GetClient(serverId)
-            ?? throw new InvalidOperationException("Server not connected");
-
         var serverDir = Path.Combine(_tempDir, serverId);
         if (!Directory.Exists(serverDir))
             Directory.CreateDirectory(serverDir);
@@ -67,15 +64,18 @@ public class RemoteFileEditService : IRemoteFileEditService, IDisposable
             {
                 try
                 {
+                    var remoteStream = await _remoteFileService.OpenReadAsync(serverId, remotePath);
                     await Task.Run(() =>
                     {
-                        using var remoteStream = client.OpenRead(remotePath);
-                        using var localStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
-                        var buffer = new byte[81920];
-                        int bytesRead;
-                        while ((bytesRead = remoteStream.Read(buffer, 0, buffer.Length)) > 0)
+                        using (remoteStream)
+                        using (var localStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
                         {
-                            localStream.Write(buffer, 0, bytesRead);
+                            var buffer = new byte[81920];
+                            int bytesRead;
+                            while ((bytesRead = remoteStream.Read(buffer, 0, buffer.Length)) > 0)
+                            {
+                                localStream.Write(buffer, 0, bytesRead);
+                            }
                         }
                     }, CancellationToken.None);
                     break;
@@ -124,18 +124,19 @@ public class RemoteFileEditService : IRemoteFileEditService, IDisposable
 
         try
         {
-            var client = _connectionService.GetClient(serverId)
-                ?? throw new InvalidOperationException("Server not connected");
+            var remoteStream = await _remoteFileService.OpenWriteAsync(serverId, remotePath);
 
             await Task.Run(() =>
             {
-                using var localStream = File.OpenRead(localPath);
-                using var remoteStream = client.OpenWrite(remotePath);
-                var buffer = new byte[81920];
-                int bytesRead;
-                while ((bytesRead = localStream.Read(buffer, 0, buffer.Length)) > 0)
+                using (remoteStream)
+                using (var localStream = File.OpenRead(localPath))
                 {
-                    remoteStream.Write(buffer, 0, bytesRead);
+                    var buffer = new byte[81920];
+                    int bytesRead;
+                    while ((bytesRead = localStream.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        remoteStream.Write(buffer, 0, bytesRead);
+                    }
                 }
             });
 

--- a/Services/Impl/RemoteFileServiceRouter.cs
+++ b/Services/Impl/RemoteFileServiceRouter.cs
@@ -1,0 +1,106 @@
+using MacExplorer.Models;
+
+namespace MacExplorer.Services.Impl;
+
+/// <summary>
+/// Dispatches remote file operations to the backend that owns the server, so the
+/// rest of the app keeps depending on a single <see cref="IRemoteFileService"/>.
+/// The server is taken from the path's <see cref="VirtualPath.RemotePrefix"/>
+/// sentinel when it has one, and from the current server otherwise.
+/// </summary>
+public class RemoteFileServiceRouter : IRemoteFileService
+{
+    private readonly IRemoteConnectionService _connectionService;
+    private readonly SftpFileService _sftp;
+    private readonly OssFileService _oss;
+    private string? _currentServerId;
+
+    public RemoteFileServiceRouter(
+        IRemoteConnectionService connectionService,
+        SftpFileService sftp,
+        OssFileService oss)
+    {
+        _connectionService = connectionService;
+        _sftp = sftp;
+        _oss = oss;
+    }
+
+    public void SetCurrentServer(string serverId)
+    {
+        _currentServerId = serverId;
+        // Both backends track it so path-less members (HomeDirectory, ...) stay consistent.
+        _sftp.SetCurrentServer(serverId);
+        _oss.SetCurrentServer(serverId);
+    }
+
+    private IRemoteFileService ForServer(string? serverId)
+    {
+        if (serverId == null) return _sftp;
+        var server = _connectionService.GetServer(serverId);
+        return server?.Protocol == RemoteProtocol.AliyunOss ? _oss : _sftp;
+    }
+
+    private IRemoteFileService ForPath(string? path)
+        => ForServer(VirtualPath.IsRemotePath(path) ? VirtualPath.ParseRemotePath(path!).ServerId : _currentServerId);
+
+    private IRemoteFileService Current => ForServer(_currentServerId);
+
+    public string HomeDirectory => Current.HomeDirectory;
+    public string RootDirectory => Current.RootDirectory;
+    public string TrashDirectory => Current.TrashDirectory;
+
+    public Task<IReadOnlyList<FileSystemEntry>> GetDirectoryContentsAsync(string path, CancellationToken cancellationToken = default)
+        => ForPath(path).GetDirectoryContentsAsync(path, cancellationToken);
+
+    public IAsyncEnumerable<IReadOnlyList<FileSystemEntry>> EnumerateDirectoryBatchesAsync(string path, int batchSize = 256, CancellationToken cancellationToken = default)
+        => ForPath(path).EnumerateDirectoryBatchesAsync(path, batchSize, cancellationToken);
+
+    public Task<FileSystemEntry?> GetEntryAsync(string path) => ForPath(path).GetEntryAsync(path);
+
+    public Task<bool> ExistsAsync(string path) => ForPath(path).ExistsAsync(path);
+
+    public Task<string> CreateFolderAsync(string parentPath, string name) => ForPath(parentPath).CreateFolderAsync(parentPath, name);
+
+    public Task<string> CreateFileAsync(string parentPath, string name) => ForPath(parentPath).CreateFileAsync(parentPath, name);
+
+    public Task<string> CreateFileWithContentAsync(string parentPath, string name, byte[] content)
+        => ForPath(parentPath).CreateFileWithContentAsync(parentPath, name, content);
+
+    public Task DeleteAsync(string path, bool moveToTrash = true) => ForPath(path).DeleteAsync(path, moveToTrash);
+
+    public Task RenameAsync(string path, string newName) => ForPath(path).RenameAsync(path, newName);
+
+    public Task MoveAsync(string sourcePath, string destinationDirectory, bool overwrite = false)
+        => ForPath(sourcePath).MoveAsync(sourcePath, destinationDirectory, overwrite);
+
+    public Task CopyAsync(string sourcePath, string destinationDirectory)
+        => ForPath(sourcePath).CopyAsync(sourcePath, destinationDirectory);
+
+    public string GetParentPath(string path) => ForPath(path).GetParentPath(path);
+
+    public string CombinePath(string directory, string name) => ForPath(directory).CombinePath(directory, name);
+
+    public IReadOnlyList<string> GetVolumes() => Current.GetVolumes();
+
+    public Task DeletePermanentlyAsync(string path) => ForPath(path).DeletePermanentlyAsync(path);
+
+    public Task EmptyTrashAsync() => Current.EmptyTrashAsync();
+
+    public Task ResolveAppIconsAsync(IEnumerable<FileSystemEntry> entries, Action? onBatchResolved = null, CancellationToken cancellationToken = default)
+        => Current.ResolveAppIconsAsync(entries, onBatchResolved, cancellationToken);
+
+    public bool IsCrossVolume(string sourcePath, string destinationPath) => ForPath(sourcePath).IsCrossVolume(sourcePath, destinationPath);
+
+    public Task MoveWithProgressAsync(IReadOnlyList<string> sourcePaths, string destinationDirectory,
+        IProgress<FileOperationProgress>? progress = null, CancellationToken ct = default)
+        => ForPath(sourcePaths.FirstOrDefault()).MoveWithProgressAsync(sourcePaths, destinationDirectory, progress, ct);
+
+    public Task<Stream> OpenReadAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+        => ForServer(serverId).OpenReadAsync(serverId, remotePath, cancellationToken);
+
+    public Task<Stream> OpenWriteAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+        => ForServer(serverId).OpenWriteAsync(serverId, remotePath, cancellationToken);
+
+    public Task<long> GetFileSizeAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+        => ForServer(serverId).GetFileSizeAsync(serverId, remotePath, cancellationToken);
+}

--- a/Services/OssFileService.cs
+++ b/Services/OssFileService.cs
@@ -1,0 +1,600 @@
+using System.Runtime.CompilerServices;
+using Aliyun.OSS;
+using Aliyun.OSS.Common;
+using MacExplorer.Models;
+using MacExplorer.Services.Impl;
+using Microsoft.Extensions.Logging;
+
+namespace MacExplorer.Services;
+
+/// <summary>
+/// Aliyun OSS backend. OSS is a flat key/value store, so "directories" are
+/// synthesised from the common prefixes returned by a delimiter listing, plus the
+/// zero-byte <c>foo/</c> placeholder objects the OSS console creates.
+/// </summary>
+public class OssFileService : IRemoteFileService, IDisposable
+{
+    /// <summary>OSS caps a single ListObjects page at 1000 keys.</summary>
+    private const int MaxKeysPerPage = 1000;
+
+    /// <summary>Server-side CopyObject is limited to 1 GB; larger objects need a multipart copy.</summary>
+    private const long MaxSingleCopySize = 1024L * 1024 * 1024;
+
+    private readonly IRemoteConnectionService _connectionService;
+    private readonly ILogger<OssFileService>? _logger;
+    private readonly string _tempDir;
+    private readonly Dictionary<string, (string Signature, IOss Client)> _clients = new();
+    private string? _currentServerId;
+
+    public OssFileService(IRemoteConnectionService connectionService, ILogger<OssFileService>? logger = null)
+    {
+        _connectionService = connectionService;
+        _logger = logger;
+        _tempDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "MacExplorer", "oss-temp");
+        if (!Directory.Exists(_tempDir))
+            Directory.CreateDirectory(_tempDir);
+    }
+
+    public void SetCurrentServer(string serverId) => _currentServerId = serverId;
+
+    public string HomeDirectory => "/";
+    public string RootDirectory => "/";
+    public string TrashDirectory => "__remote_trash__";
+
+    // ---------------------------------------------------------------- key mapping
+
+    /// <summary>Sentinel or POSIX path to an OSS object key: "/a/b.txt" → "a/b.txt", "/" → "".</summary>
+    internal static string ToObjectKey(string path)
+    {
+        var remotePath = RemotePathHelper.ToRemotePath(path).Replace('\\', '/');
+        return remotePath.TrimStart('/');
+    }
+
+    /// <summary>Key to the prefix used to enumerate its children: "a/b" → "a/b/", "" → "".</summary>
+    internal static string ToPrefix(string key)
+        => key.Length == 0 ? string.Empty : key.TrimEnd('/') + "/";
+
+    /// <summary>Last path segment of a key, with any trailing slash removed.</summary>
+    internal static string KeyToName(string key)
+    {
+        var trimmed = key.TrimEnd('/');
+        var slash = trimmed.LastIndexOf('/');
+        return slash < 0 ? trimmed : trimmed[(slash + 1)..];
+    }
+
+    private (IOss Client, string Bucket) GetContext(string serverId)
+    {
+        var server = _connectionService.GetServer(serverId)
+            ?? throw new InvalidOperationException($"Server {serverId} is not connected");
+        if (!server.IsOss)
+            throw new InvalidOperationException($"Server {server.DisplayName} is not an OSS server");
+
+        // Rebuild the client when credentials change so an edited server takes effect.
+        var signature = $"{server.Endpoint}|{server.AccessKeyId}|{server.AccessKeySecret}|{server.Bucket}";
+        lock (_clients)
+        {
+            if (_clients.TryGetValue(serverId, out var cached) && cached.Signature == signature)
+                return (cached.Client, server.Bucket);
+
+            var client = OssClientFactory.Create(server);
+            _clients[serverId] = (signature, client);
+            return (client, server.Bucket);
+        }
+    }
+
+    private (IOss Client, string Bucket, string ServerId) GetContext()
+    {
+        var id = _currentServerId ?? throw new InvalidOperationException("No remote server selected");
+        var (client, bucket) = GetContext(id);
+        return (client, bucket, id);
+    }
+
+    /// <summary>Resolves the server from the path when it carries one, else the current server.</summary>
+    private (IOss Client, string Bucket, string ServerId) GetContextForPath(string path)
+    {
+        if (!VirtualPath.IsRemotePath(path)) return GetContext();
+        var serverId = VirtualPath.ParseRemotePath(path).ServerId;
+        var (client, bucket) = GetContext(serverId);
+        return (client, bucket, serverId);
+    }
+
+    // ---------------------------------------------------------------- listing
+
+    public async Task<IReadOnlyList<FileSystemEntry>> GetDirectoryContentsAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var entries = new List<FileSystemEntry>();
+        await foreach (var batch in EnumerateDirectoryBatchesAsync(path, MaxKeysPerPage, cancellationToken))
+            entries.AddRange(batch);
+        return entries;
+    }
+
+    public async IAsyncEnumerable<IReadOnlyList<FileSystemEntry>> EnumerateDirectoryBatchesAsync(
+        string path, int batchSize = 256,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        batchSize = Math.Clamp(batchSize, 32, 1024);
+        var (client, bucket, serverId) = GetContextForPath(path);
+        var prefix = ToPrefix(ToObjectKey(path));
+
+        var batch = new List<FileSystemEntry>(batchSize);
+        string? marker = null;
+
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var currentMarker = marker;
+            var listing = await Task.Run(() => client.ListObjects(new ListObjectsRequest(bucket)
+            {
+                Prefix = prefix,
+                Delimiter = "/",
+                Marker = currentMarker,
+                MaxKeys = MaxKeysPerPage
+            }), cancellationToken);
+
+            foreach (var commonPrefix in listing.CommonPrefixes)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                batch.Add(CreateDirectoryEntry(commonPrefix, serverId));
+                if (batch.Count < batchSize) continue;
+                yield return batch.ToArray();
+                batch.Clear();
+            }
+
+            foreach (var summary in listing.ObjectSummaries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // The placeholder object standing for the directory itself.
+                if (summary.Key == prefix) continue;
+                batch.Add(CreateFileEntry(summary, serverId));
+                if (batch.Count < batchSize) continue;
+                yield return batch.ToArray();
+                batch.Clear();
+            }
+
+            marker = listing.IsTruncated ? listing.NextMarker : null;
+        }
+        while (!string.IsNullOrEmpty(marker));
+
+        if (batch.Count > 0)
+            yield return batch.ToArray();
+    }
+
+    public async Task<FileSystemEntry?> GetEntryAsync(string path)
+    {
+        var (client, bucket, serverId) = GetContextForPath(path);
+        var key = ToObjectKey(path);
+
+        if (key.Length == 0)
+        {
+            return new FileSystemEntry
+            {
+                FullPath = VirtualPath.BuildRemotePath(serverId, "/"),
+                Name = "/",
+                IsDirectory = true,
+                IconKey = "folder",
+                IsReadable = true,
+                IsWritable = true
+            };
+        }
+
+        return await Task.Run(() =>
+        {
+            try
+            {
+                var metadata = client.GetObjectMetadata(bucket, key);
+                return CreateEntryFromMetadata(KeyToName(key), key, metadata, serverId);
+            }
+            catch (OssException)
+            {
+                // Not an object — it may still be a prefix with children under it.
+                return IsDirectoryKey(client, bucket, key)
+                    ? CreateDirectoryEntry(ToPrefix(key), serverId)
+                    : null;
+            }
+        });
+    }
+
+    public async Task<bool> ExistsAsync(string path)
+    {
+        var (client, bucket, _) = GetContextForPath(path);
+        var key = ToObjectKey(path);
+        if (key.Length == 0) return true;
+        return await Task.Run(() => client.DoesObjectExist(bucket, key) || IsDirectoryKey(client, bucket, key));
+    }
+
+    private static bool IsDirectoryKey(IOss client, string bucket, string key)
+    {
+        var prefix = ToPrefix(key);
+        if (prefix.Length == 0) return true;
+        var listing = client.ListObjects(new ListObjectsRequest(bucket) { Prefix = prefix, MaxKeys = 1 });
+        return listing.ObjectSummaries.Any();
+    }
+
+    // ---------------------------------------------------------------- create
+
+    public async Task<string> CreateFolderAsync(string parentPath, string name)
+    {
+        var (client, bucket, serverId) = GetContextForPath(parentPath);
+        var key = ToPrefix(ToObjectKey(parentPath)) + name.TrimEnd('/');
+        return await Task.Run(() =>
+        {
+            // A zero-byte "foo/" object is how OSS represents an empty directory.
+            using var empty = new MemoryStream();
+            client.PutObject(bucket, key + "/", empty);
+            return VirtualPath.BuildRemotePath(serverId, "/" + key);
+        });
+    }
+
+    public Task<string> CreateFileAsync(string parentPath, string name)
+        => CreateFileWithContentAsync(parentPath, name, []);
+
+    public async Task<string> CreateFileWithContentAsync(string parentPath, string name, byte[] content)
+    {
+        var (client, bucket, serverId) = GetContextForPath(parentPath);
+        var key = ToPrefix(ToObjectKey(parentPath)) + name;
+        return await Task.Run(() =>
+        {
+            using var stream = new MemoryStream(content);
+            client.PutObject(bucket, key, stream);
+            return VirtualPath.BuildRemotePath(serverId, "/" + key);
+        });
+    }
+
+    // ---------------------------------------------------------------- delete
+
+    public async Task DeleteAsync(string path, bool moveToTrash = true)
+    {
+        // OSS has no trash; deletes are always permanent.
+        var (client, bucket, _) = GetContextForPath(path);
+        var key = ToObjectKey(path);
+        if (key.Length == 0)
+            throw new InvalidOperationException("Cannot delete the bucket root");
+
+        await Task.Run(() =>
+        {
+            var childKeys = ListAllKeys(client, bucket, ToPrefix(key)).ToList();
+            if (childKeys.Count > 0)
+            {
+                DeleteKeys(client, bucket, childKeys);
+                return;
+            }
+            client.DeleteObject(bucket, key);
+        });
+    }
+
+    public Task DeletePermanentlyAsync(string path) => DeleteAsync(path, moveToTrash: false);
+
+    public Task EmptyTrashAsync() => Task.CompletedTask;
+
+    private static void DeleteKeys(IOss client, string bucket, IReadOnlyList<string> keys)
+    {
+        for (var i = 0; i < keys.Count; i += MaxKeysPerPage)
+        {
+            var page = keys.Skip(i).Take(MaxKeysPerPage).ToList();
+            client.DeleteObjects(new DeleteObjectsRequest(bucket, page, quiet: true));
+        }
+    }
+
+    /// <summary>Every key under a prefix, recursively (no delimiter), following pagination.</summary>
+    private static IEnumerable<string> ListAllKeys(IOss client, string bucket, string prefix)
+    {
+        string? marker = null;
+        do
+        {
+            var listing = client.ListObjects(new ListObjectsRequest(bucket)
+            {
+                Prefix = prefix,
+                Marker = marker,
+                MaxKeys = MaxKeysPerPage
+            });
+
+            foreach (var summary in listing.ObjectSummaries)
+                yield return summary.Key;
+
+            marker = listing.IsTruncated ? listing.NextMarker : null;
+        }
+        while (!string.IsNullOrEmpty(marker));
+    }
+
+    // ---------------------------------------------------------------- move / copy
+
+    public Task RenameAsync(string path, string newName)
+    {
+        var parentPath = GetParentPath(path);
+        var newPath = CombinePath(parentPath, newName);
+        return TransferAsync(path, newPath, deleteSource: true);
+    }
+
+    public Task MoveAsync(string sourcePath, string destinationDirectory, bool overwrite = false)
+    {
+        var destPath = CombinePath(destinationDirectory, KeyToName(ToObjectKey(sourcePath)));
+        return TransferAsync(sourcePath, destPath, deleteSource: true, overwrite: overwrite);
+    }
+
+    public Task CopyAsync(string sourcePath, string destinationDirectory)
+    {
+        var destPath = CombinePath(destinationDirectory, KeyToName(ToObjectKey(sourcePath)));
+        return TransferAsync(sourcePath, destPath, deleteSource: false);
+    }
+
+    private async Task TransferAsync(string sourcePath, string destPath, bool deleteSource, bool overwrite = true)
+    {
+        var (client, bucket, _) = GetContextForPath(sourcePath);
+        var sourceKey = ToObjectKey(sourcePath);
+        var destKey = ToObjectKey(destPath);
+        if (sourceKey.Length == 0)
+            throw new InvalidOperationException("Cannot move the bucket root");
+        if (string.Equals(sourceKey, destKey, StringComparison.Ordinal)) return;
+
+        await Task.Run(() =>
+        {
+            var childKeys = ListAllKeys(client, bucket, ToPrefix(sourceKey)).ToList();
+            if (childKeys.Count > 0)
+            {
+                var sourcePrefix = ToPrefix(sourceKey);
+                var destPrefix = ToPrefix(destKey);
+                foreach (var childKey in childKeys)
+                {
+                    var relative = childKey[sourcePrefix.Length..];
+                    CopyKey(client, bucket, childKey, destPrefix + relative);
+                }
+                if (deleteSource)
+                    DeleteKeys(client, bucket, childKeys);
+                return;
+            }
+
+            if (!overwrite && client.DoesObjectExist(bucket, destKey))
+                throw new IOException($"File already exists: {destKey}");
+
+            CopyKey(client, bucket, sourceKey, destKey);
+            if (deleteSource)
+                client.DeleteObject(bucket, sourceKey);
+        });
+    }
+
+    private static void CopyKey(IOss client, string bucket, string sourceKey, string destKey)
+    {
+        var request = new CopyObjectRequest(bucket, sourceKey, bucket, destKey);
+        var size = TryGetSize(client, bucket, sourceKey);
+        if (size > MaxSingleCopySize)
+        {
+            var checkpointDir = Path.Combine(Path.GetTempPath(), "MacExplorer", "oss-copy");
+            Directory.CreateDirectory(checkpointDir);
+            client.ResumableCopyObject(request, checkpointDir);
+            return;
+        }
+        client.CopyObject(request);
+    }
+
+    private static long TryGetSize(IOss client, string bucket, string key)
+    {
+        try
+        {
+            return client.GetObjectMetadata(bucket, key).ContentLength;
+        }
+        catch (OssException)
+        {
+            return 0;
+        }
+    }
+
+    public async Task MoveWithProgressAsync(IReadOnlyList<string> sourcePaths, string destinationDirectory,
+        IProgress<FileOperationProgress>? progress = null, CancellationToken ct = default)
+    {
+        var (client, bucket, _) = GetContextForPath(destinationDirectory);
+        var destPrefix = ToPrefix(ToObjectKey(destinationDirectory));
+
+        await Task.Run(() =>
+        {
+            // Server-side copies report no byte progress, so weight by object size.
+            var plan = new List<(string SourceKey, string DestKey, long Size)>();
+            foreach (var sourcePath in sourcePaths)
+            {
+                ct.ThrowIfCancellationRequested();
+                var sourceKey = ToObjectKey(sourcePath);
+                if (sourceKey.Length == 0) continue;
+
+                var childKeys = ListAllKeys(client, bucket, ToPrefix(sourceKey)).ToList();
+                if (childKeys.Count > 0)
+                {
+                    var sourcePrefix = ToPrefix(sourceKey);
+                    var targetPrefix = destPrefix + KeyToName(sourceKey) + "/";
+                    foreach (var childKey in childKeys)
+                        plan.Add((childKey, targetPrefix + childKey[sourcePrefix.Length..], TryGetSize(client, bucket, childKey)));
+                }
+                else
+                {
+                    plan.Add((sourceKey, destPrefix + KeyToName(sourceKey), TryGetSize(client, bucket, sourceKey)));
+                }
+            }
+
+            var totalBytes = Math.Max(1, plan.Sum(item => item.Size));
+            long movedBytes = 0;
+
+            foreach (var (sourceKey, destKey, size) in plan)
+            {
+                ct.ThrowIfCancellationRequested();
+                CopyKey(client, bucket, sourceKey, destKey);
+                movedBytes += size;
+                progress?.Report(new FileOperationProgress
+                {
+                    Percentage = (double)movedBytes / totalBytes * 100,
+                    CurrentFile = KeyToName(sourceKey)
+                });
+            }
+
+            if (plan.Count > 0)
+                DeleteKeys(client, bucket, plan.Select(item => item.SourceKey).ToList());
+        }, ct);
+    }
+
+    // ---------------------------------------------------------------- streams
+
+    public async Task<Stream> OpenReadAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        var (client, bucket) = GetContext(serverId);
+        var key = ToObjectKey(remotePath);
+        return await Task.Run(() => client.GetObject(bucket, key).Content, cancellationToken);
+    }
+
+    public Task<Stream> OpenWriteAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        var (client, bucket) = GetContext(serverId);
+        var key = ToObjectKey(remotePath);
+        Stream stream = new OssUploadStream(client, bucket, key, _tempDir);
+        return Task.FromResult(stream);
+    }
+
+    public async Task<long> GetFileSizeAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        var (client, bucket) = GetContext(serverId);
+        var key = ToObjectKey(remotePath);
+        return await Task.Run(() => TryGetSize(client, bucket, key), cancellationToken);
+    }
+
+    /// <summary>
+    /// OSS uploads need the full payload up front, so writes are spooled to a temp
+    /// file and committed with a single PutObject when the stream is disposed.
+    /// </summary>
+    private sealed class OssUploadStream : Stream
+    {
+        private readonly IOss _client;
+        private readonly string _bucket;
+        private readonly string _key;
+        private readonly string _tempPath;
+        private readonly FileStream _buffer;
+        private bool _committed;
+
+        public OssUploadStream(IOss client, string bucket, string key, string tempDir)
+        {
+            _client = client;
+            _bucket = bucket;
+            _key = key;
+            _tempPath = Path.Combine(tempDir, Guid.NewGuid().ToString("N") + ".upload");
+            _buffer = new FileStream(_tempPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _buffer.Length;
+        public override long Position
+        {
+            get => _buffer.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) => _buffer.Write(buffer, offset, count);
+        public override void Flush() => _buffer.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposing || _committed)
+            {
+                base.Dispose(disposing);
+                return;
+            }
+
+            _committed = true;
+            try
+            {
+                _buffer.Flush();
+                _buffer.Position = 0;
+                _client.PutObject(_bucket, _key, _buffer);
+            }
+            finally
+            {
+                _buffer.Dispose();
+                try { File.Delete(_tempPath); } catch { }
+                base.Dispose(disposing);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- misc
+
+    public string GetParentPath(string path) => RemotePathHelper.GetParentPath(path);
+
+    public string CombinePath(string directory, string name) => RemotePathHelper.CombinePath(directory, name);
+
+    public IReadOnlyList<string> GetVolumes() => [];
+
+    public Task ResolveAppIconsAsync(
+        IEnumerable<FileSystemEntry> entries,
+        Action? onBatchResolved = null,
+        CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public bool IsCrossVolume(string sourcePath, string destinationPath) => false;
+
+    private static FileSystemEntry CreateDirectoryEntry(string prefix, string serverId)
+    {
+        var name = KeyToName(prefix);
+        return new FileSystemEntry
+        {
+            FullPath = VirtualPath.BuildRemotePath(serverId, "/" + prefix.TrimEnd('/')),
+            Name = name,
+            IsDirectory = true,
+            Size = 0,
+            Extension = "",
+            IsHidden = name.StartsWith('.'),
+            IsReadable = true,
+            IsWritable = true,
+            IconKey = "folder"
+        };
+    }
+
+    private static FileSystemEntry CreateFileEntry(OssObjectSummary summary, string serverId)
+    {
+        var name = KeyToName(summary.Key);
+        var ext = Path.GetExtension(name).ToLowerInvariant();
+        return new FileSystemEntry
+        {
+            FullPath = VirtualPath.BuildRemotePath(serverId, "/" + summary.Key),
+            Name = name,
+            IsDirectory = false,
+            Size = summary.Size,
+            LastModified = summary.LastModified.ToLocalTime(),
+            Created = summary.LastModified.ToLocalTime(),
+            Extension = ext,
+            IsHidden = name.StartsWith('.'),
+            IsReadable = true,
+            IsWritable = true,
+            IconKey = FileIconResolver.ResolveIconKey(ext)
+        };
+    }
+
+    private static FileSystemEntry CreateEntryFromMetadata(string name, string key, ObjectMetadata metadata, string serverId)
+    {
+        var ext = Path.GetExtension(name).ToLowerInvariant();
+        return new FileSystemEntry
+        {
+            FullPath = VirtualPath.BuildRemotePath(serverId, "/" + key),
+            Name = name,
+            IsDirectory = false,
+            Size = metadata.ContentLength,
+            LastModified = metadata.LastModified.ToLocalTime(),
+            Created = metadata.LastModified.ToLocalTime(),
+            Extension = ext,
+            IsHidden = name.StartsWith('.'),
+            IsReadable = true,
+            IsWritable = true,
+            IconKey = FileIconResolver.ResolveIconKey(ext)
+        };
+    }
+
+    public void Dispose()
+    {
+        lock (_clients) _clients.Clear();
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, true);
+        }
+        catch { }
+    }
+}

--- a/Services/RemotePathHelper.cs
+++ b/Services/RemotePathHelper.cs
@@ -1,0 +1,44 @@
+namespace MacExplorer.Services;
+
+/// <summary>
+/// POSIX-style path arithmetic shared by every remote backend. Accepts both raw
+/// remote paths and <see cref="VirtualPath.RemotePrefix"/> sentinel paths, and
+/// preserves whichever form it was given.
+/// </summary>
+internal static class RemotePathHelper
+{
+    public static string GetParentPath(string path)
+    {
+        if (VirtualPath.IsRemotePath(path))
+        {
+            var (serverId, remotePath) = VirtualPath.ParseRemotePath(path);
+            if (string.IsNullOrEmpty(remotePath) || remotePath == "/")
+                return VirtualPath.BuildRemotePath(serverId, "/");
+            var normalized = remotePath.TrimEnd('/');
+            var lastSlash = normalized.LastIndexOf('/');
+            var parentRemote = lastSlash <= 0 ? "/" : normalized[..lastSlash];
+            return VirtualPath.BuildRemotePath(serverId, parentRemote);
+        }
+        if (string.IsNullOrEmpty(path) || path == "/") return "/";
+        var norm = path.TrimEnd('/');
+        var ls = norm.LastIndexOf('/');
+        return ls <= 0 ? "/" : norm[..ls];
+    }
+
+    public static string CombinePath(string directory, string name)
+    {
+        if (VirtualPath.IsRemotePath(directory))
+        {
+            var (serverId, remotePath) = VirtualPath.ParseRemotePath(directory);
+            var combined = CombinePath(remotePath, name);
+            return VirtualPath.BuildRemotePath(serverId, combined);
+        }
+        if (string.IsNullOrEmpty(directory) || directory == "/")
+            return "/" + name;
+        return directory.TrimEnd('/') + "/" + name;
+    }
+
+    /// <summary>Strips the sentinel prefix, leaving the backend-native path.</summary>
+    public static string ToRemotePath(string path)
+        => VirtualPath.IsRemotePath(path) ? VirtualPath.ParseRemotePath(path).RemotePath : path;
+}

--- a/Services/SftpFileService.cs
+++ b/Services/SftpFileService.cs
@@ -28,20 +28,45 @@ public class SftpFileService : IRemoteFileService, IDisposable
     public void SetCurrentServer(string serverId) => _currentServerId = serverId;
 
     private SftpClient GetClient()
-    {
-        var id = _currentServerId ?? throw new InvalidOperationException("No remote server selected");
-        return _connectionService.GetClient(id) ?? throw new InvalidOperationException($"Server {id} is not connected");
-    }
+        => GetClient(_currentServerId ?? throw new InvalidOperationException("No remote server selected"));
+
+    private SftpClient GetClient(string serverId)
+        => _connectionService.GetSftpClient(serverId)
+           ?? throw new InvalidOperationException($"Server {serverId} is not connected");
 
     private string GetServerId() => _currentServerId ?? throw new InvalidOperationException("No remote server selected");
 
-    private string ToRemotePath(string path) => VirtualPath.IsRemotePath(path) ? VirtualPath.ParseRemotePath(path).RemotePath : path;
+    private static string ToRemotePath(string path) => RemotePathHelper.ToRemotePath(path);
 
-    public Renci.SshNet.SftpClient? GetConnectedClient()
+    public async Task<Stream> OpenReadAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
     {
-        var id = _currentServerId;
-        if (id == null) return null;
-        return _connectionService.GetClient(id);
+        var client = GetClient(serverId);
+        var path = ToRemotePath(remotePath);
+        return await Task.Run(() => (Stream)client.OpenRead(path), cancellationToken);
+    }
+
+    public async Task<Stream> OpenWriteAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        var client = GetClient(serverId);
+        var path = ToRemotePath(remotePath);
+        return await Task.Run(() => (Stream)client.OpenWrite(path), cancellationToken);
+    }
+
+    public async Task<long> GetFileSizeAsync(string serverId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        var client = GetClient(serverId);
+        var path = ToRemotePath(remotePath);
+        return await Task.Run(() =>
+        {
+            try
+            {
+                return client.GetAttributes(path)?.Size ?? 0;
+            }
+            catch
+            {
+                return 0;
+            }
+        }, cancellationToken);
     }
 
     public string HomeDirectory => "/";
@@ -267,36 +292,9 @@ public class SftpFileService : IRemoteFileService, IDisposable
         }
     }
 
-    public string GetParentPath(string path)
-    {
-        if (VirtualPath.IsRemotePath(path))
-        {
-            var (serverId, remotePath) = VirtualPath.ParseRemotePath(path);
-            if (string.IsNullOrEmpty(remotePath) || remotePath == "/")
-                return VirtualPath.BuildRemotePath(serverId, "/");
-            var normalized = remotePath.TrimEnd('/');
-            var lastSlash = normalized.LastIndexOf('/');
-            var parentRemote = lastSlash <= 0 ? "/" : normalized[..lastSlash];
-            return VirtualPath.BuildRemotePath(serverId, parentRemote);
-        }
-        if (string.IsNullOrEmpty(path) || path == "/") return "/";
-        var norm = path.TrimEnd('/');
-        var ls = norm.LastIndexOf('/');
-        return ls <= 0 ? "/" : norm[..ls];
-    }
+    public string GetParentPath(string path) => RemotePathHelper.GetParentPath(path);
 
-    public string CombinePath(string directory, string name)
-    {
-        if (VirtualPath.IsRemotePath(directory))
-        {
-            var (serverId, remotePath) = VirtualPath.ParseRemotePath(directory);
-            var combined = CombinePath(remotePath, name);
-            return VirtualPath.BuildRemotePath(serverId, combined);
-        }
-        if (string.IsNullOrEmpty(directory) || directory == "/")
-            return "/" + name;
-        return directory.TrimEnd('/') + "/" + name;
-    }
+    public string CombinePath(string directory, string name) => RemotePathHelper.CombinePath(directory, name);
 
     public IReadOnlyList<string> GetVolumes() => Array.Empty<string>();
 

--- a/Tests/MacExplorer.Tests/FileListLoadingPipelineTests.cs
+++ b/Tests/MacExplorer.Tests/FileListLoadingPipelineTests.cs
@@ -498,7 +498,9 @@ public sealed class FileListLoadingPipelineTests
         }
 
         public void SetCurrentServer(string serverId) => CurrentServerId = serverId;
-        public SftpClient? GetConnectedClient() => null;
+        public Task<Stream> OpenReadAsync(string serverId, string remotePath, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Stream> OpenWriteAsync(string serverId, string remotePath, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> GetFileSizeAsync(string serverId, string remotePath, CancellationToken cancellationToken = default) => Task.FromResult(0L);
 
         public Task<IReadOnlyList<FileSystemEntry>> GetDirectoryContentsAsync(
             string path,
@@ -563,12 +565,13 @@ public sealed class FileListLoadingPipelineTests
             IsConnected = true,
         };
 
-        public Task<SftpClient> GetOrConnectAsync(RemoteServerInfo server, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<SftpClient> ConnectAsync(RemoteServerInfo server, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task GetOrConnectAsync(RemoteServerInfo server, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task ConnectAsync(RemoteServerInfo server, CancellationToken ct = default) => throw new NotSupportedException();
         public void Disconnect(string id) { }
         public void DisconnectAll() { }
         public bool IsConnected(string id) => string.Equals(id, serverId, StringComparison.Ordinal);
-        public SftpClient? GetClient(string id) => null;
+        public RemoteServerInfo? GetServer(string id) => string.Equals(id, serverId, StringComparison.Ordinal) ? _server : null;
+        public SftpClient? GetSftpClient(string id) => null;
         public IReadOnlyList<RemoteServerInfo> GetSavedServers() => [_server];
         public void SaveServer(RemoteServerInfo server) { }
         public void RemoveServer(string id) { }

--- a/Tests/MacExplorer.Tests/OssFileServiceTests.cs
+++ b/Tests/MacExplorer.Tests/OssFileServiceTests.cs
@@ -47,6 +47,47 @@ public class OssFileServiceTests
         Assert.Equal(expected, OssClientFactory.NormalizeEndpoint(endpoint));
     }
 
+    [Theory]
+    [InlineData("my-bucket", "my-bucket")]
+    [InlineData("my-bucket.oss-cn-shenzhen.aliyuncs.com", "my-bucket")]
+    [InlineData("oss://my-bucket/", "my-bucket")]
+    [InlineData("https://my-bucket.oss-cn-shenzhen.aliyuncs.com", "my-bucket")]
+    [InlineData("  my-bucket  ", "my-bucket")]
+    [InlineData("", "")]
+    public void NormalizeBucket_StripsEndpointSuffixAndScheme(string bucket, string expected)
+    {
+        Assert.Equal(expected, OssClientFactory.NormalizeBucket(bucket));
+    }
+
+    [Theory]
+    [InlineData("my-bucket.oss-cn-shenzhen.aliyuncs.com", "oss-cn-shenzhen.aliyuncs.com")]
+    [InlineData("https://my-bucket.oss-cn-shenzhen.aliyuncs.com", "oss-cn-shenzhen.aliyuncs.com")]
+    [InlineData("oss-cn-shenzhen.aliyuncs.com", "oss-cn-shenzhen.aliyuncs.com")]
+    public void NormalizeEndpoint_StripsBucketPrefix(string endpoint, string expected)
+    {
+        Assert.Equal(expected, OssClientFactory.NormalizeEndpoint(endpoint));
+    }
+
+    [Theory]
+    [InlineData("oss://my-bucket/", "my-bucket", "/")]
+    [InlineData("oss://my-bucket/photos", "my-bucket", "/photos")]
+    [InlineData("oss://my-bucket/photos/2026/", "my-bucket", "/photos/2026")]
+    [InlineData("photos", "my-bucket", "/photos")]
+    [InlineData("/photos/", "my-bucket", "/photos")]
+    [InlineData("", "my-bucket", "/")]
+    [InlineData("/", "my-bucket", "/")]
+    public void NormalizeDefaultPath_YieldsBucketRelativePath(string path, string bucket, string expected)
+    {
+        Assert.Equal(expected, OssClientFactory.NormalizeDefaultPath(path, bucket));
+    }
+
+    [Fact]
+    public void NormalizeDefaultPath_KeepsSegmentThatIsNotTheBucket()
+    {
+        // A folder that happens to sit at the root must not be mistaken for the bucket.
+        Assert.Equal("/photos", OssClientFactory.NormalizeDefaultPath("oss://photos", "my-bucket"));
+    }
+
     [Fact]
     public void RemotePathHelper_RoundTripsSentinelPaths()
     {

--- a/Tests/MacExplorer.Tests/OssFileServiceTests.cs
+++ b/Tests/MacExplorer.Tests/OssFileServiceTests.cs
@@ -1,0 +1,67 @@
+using MacExplorer.Services;
+using MacExplorer.Services.Impl;
+using Xunit;
+
+namespace MacExplorer.Tests;
+
+public class OssFileServiceTests
+{
+    [Theory]
+    [InlineData("__remote:srv1:/photos/2026/a.jpg", "photos/2026/a.jpg")]
+    [InlineData("__remote:srv1:/", "")]
+    [InlineData("/photos/a.jpg", "photos/a.jpg")]
+    [InlineData("photos/a.jpg", "photos/a.jpg")]
+    [InlineData("/", "")]
+    public void ToObjectKey_StripsSentinelAndLeadingSlash(string path, string expected)
+    {
+        Assert.Equal(expected, OssFileService.ToObjectKey(path));
+    }
+
+    [Theory]
+    [InlineData("photos", "photos/")]
+    [InlineData("photos/2026", "photos/2026/")]
+    [InlineData("photos/", "photos/")]
+    [InlineData("", "")]
+    public void ToPrefix_AppendsExactlyOneSlash(string key, string expected)
+    {
+        Assert.Equal(expected, OssFileService.ToPrefix(key));
+    }
+
+    [Theory]
+    [InlineData("photos/2026/a.jpg", "a.jpg")]
+    [InlineData("photos/2026/", "2026")]
+    [InlineData("a.jpg", "a.jpg")]
+    public void KeyToName_TakesLastSegment(string key, string expected)
+    {
+        Assert.Equal(expected, OssFileService.KeyToName(key));
+    }
+
+    [Theory]
+    [InlineData("oss-cn-hangzhou.aliyuncs.com", "oss-cn-hangzhou.aliyuncs.com")]
+    [InlineData("https://oss-cn-hangzhou.aliyuncs.com", "oss-cn-hangzhou.aliyuncs.com")]
+    [InlineData("http://oss-cn-hangzhou.aliyuncs.com/", "oss-cn-hangzhou.aliyuncs.com")]
+    [InlineData("  oss-cn-beijing.aliyuncs.com  ", "oss-cn-beijing.aliyuncs.com")]
+    [InlineData("", "")]
+    public void NormalizeEndpoint_AcceptsWhatUsersPaste(string endpoint, string expected)
+    {
+        Assert.Equal(expected, OssClientFactory.NormalizeEndpoint(endpoint));
+    }
+
+    [Fact]
+    public void RemotePathHelper_RoundTripsSentinelPaths()
+    {
+        var directory = VirtualPath.BuildRemotePath("srv1", "/photos");
+        var child = RemotePathHelper.CombinePath(directory, "a.jpg");
+
+        Assert.Equal("__remote:srv1:/photos/a.jpg", child);
+        Assert.Equal(directory, RemotePathHelper.GetParentPath(child));
+        Assert.Equal("photos/a.jpg", OssFileService.ToObjectKey(child));
+    }
+
+    [Fact]
+    public void RemotePathHelper_ParentOfRootStaysRoot()
+    {
+        var root = VirtualPath.BuildRemotePath("srv1", "/");
+        Assert.Equal(root, RemotePathHelper.GetParentPath(root));
+    }
+}

--- a/Views/Dialogs/RemoteConnectionDialog.axaml
+++ b/Views/Dialogs/RemoteConnectionDialog.axaml
@@ -25,12 +25,11 @@
 
     <Grid RowDefinitions="Auto,*,Auto" Margin="20,12">
         <!-- Saved servers list -->
-        <Border Grid.Row="0" IsVisible="{Binding HasSavedServers}" Margin="0,0,0,12">
+        <Border Grid.Row="0" x:Name="SavedServersBorder" IsVisible="False" Margin="0,0,0,12">
             <StackPanel>
                 <TextBlock Text="已保存的服务器" FontSize="11" FontWeight="SemiBold"
                            Foreground="{DynamicResource ColorTextTertiary}" Margin="0,0,0,6"/>
                 <ListBox x:Name="SavedServersList" MaxHeight="120"
-                         ItemsSource="{Binding SavedServers}"
                          SelectionChanged="OnSavedServerSelected">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
@@ -96,11 +95,15 @@
                 </StackPanel>
 
                 <StackPanel x:Name="OssPanel" IsVisible="False">
-                    <TextBlock Classes="label" Text="Endpoint"/>
-                    <TextBox x:Name="EndpointBox" PlaceholderText="oss-cn-hangzhou.aliyuncs.com"/>
+                    <TextBlock Text="打开 OSS 控制台 → 选中 Bucket → 概览，把「外网访问」那一行的域名整个粘到下面 Bucket 栏，Endpoint 会自动填好。"
+                               FontSize="11" Opacity="0.7" TextWrapping="Wrap" Margin="0,0,0,10"/>
 
                     <TextBlock Classes="label" Text="Bucket"/>
-                    <TextBox x:Name="BucketBox" PlaceholderText="my-bucket"/>
+                    <TextBox x:Name="BucketBox" PlaceholderText="my-bucket 或 my-bucket.oss-cn-hangzhou.aliyuncs.com"
+                             TextChanged="OnBucketTextChanged"/>
+
+                    <TextBlock Classes="label" Text="Endpoint"/>
+                    <TextBox x:Name="EndpointBox" PlaceholderText="oss-cn-hangzhou.aliyuncs.com"/>
 
                     <TextBlock Classes="label" Text="AccessKeyId"/>
                     <TextBox x:Name="AccessKeyIdBox" PlaceholderText="LTAI..."/>

--- a/Views/Dialogs/RemoteConnectionDialog.axaml
+++ b/Views/Dialogs/RemoteConnectionDialog.axaml
@@ -54,35 +54,62 @@
                 <TextBlock Classes="label" Text="服务器名称"/>
                 <TextBox x:Name="NameBox" PlaceholderText="可选，显示在侧边栏"/>
 
-                <TextBlock Classes="label" Text="主机地址"/>
-                <TextBox x:Name="HostBox" PlaceholderText="IP 地址或域名"/>
-
-                <TextBlock Classes="label" Text="端口"/>
-                <TextBox x:Name="PortBox" PlaceholderText="22"/>
-
-                <TextBlock Classes="label" Text="用户名"/>
-                <TextBox x:Name="UsernameBox" PlaceholderText="root"/>
-
-                <TextBlock Classes="label" Text="认证方式"/>
+                <TextBlock Classes="label" Text="协议"/>
                 <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,8">
-                    <RadioButton x:Name="PasswordRadio" Content="密码" IsChecked="True"
-                                 GroupName="Auth" Click="OnAuthMethodChanged"/>
-                    <RadioButton x:Name="KeyRadio" Content="密钥文件"
-                                 GroupName="Auth" Click="OnAuthMethodChanged"/>
+                    <RadioButton x:Name="SftpRadio" Content="SFTP" IsChecked="True"
+                                 GroupName="Protocol" Click="OnProtocolChanged"/>
+                    <RadioButton x:Name="OssRadio" Content="阿里云 OSS"
+                                 GroupName="Protocol" Click="OnProtocolChanged"/>
                 </StackPanel>
 
-                <StackPanel x:Name="PasswordPanel">
-                    <TextBlock Classes="label" Text="密码"/>
-                    <TextBox x:Name="PasswordBox" PlaceholderText="密码" PasswordChar="•"/>
+                <StackPanel x:Name="SftpPanel">
+                    <TextBlock Classes="label" Text="主机地址"/>
+                    <TextBox x:Name="HostBox" PlaceholderText="IP 地址或域名"/>
+
+                    <TextBlock Classes="label" Text="端口"/>
+                    <TextBox x:Name="PortBox" PlaceholderText="22"/>
+
+                    <TextBlock Classes="label" Text="用户名"/>
+                    <TextBox x:Name="UsernameBox" PlaceholderText="root"/>
+
+                    <TextBlock Classes="label" Text="认证方式"/>
+                    <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,8">
+                        <RadioButton x:Name="PasswordRadio" Content="密码" IsChecked="True"
+                                     GroupName="Auth" Click="OnAuthMethodChanged"/>
+                        <RadioButton x:Name="KeyRadio" Content="密钥文件"
+                                     GroupName="Auth" Click="OnAuthMethodChanged"/>
+                    </StackPanel>
+
+                    <StackPanel x:Name="PasswordPanel">
+                        <TextBlock Classes="label" Text="密码"/>
+                        <TextBox x:Name="PasswordBox" PlaceholderText="密码" PasswordChar="•"/>
+                    </StackPanel>
+
+                    <StackPanel x:Name="KeyPanel" IsVisible="False">
+                        <TextBlock Classes="label" Text="私钥文件路径"/>
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                            <TextBox x:Name="KeyPathBox" PlaceholderText="~/.ssh/id_rsa"/>
+                            <Button Grid.Column="1" Content="浏览" Click="OnBrowseKeyFile"
+                                    Padding="12,6" VerticalAlignment="Bottom" Margin="0,0,0,8"/>
+                        </Grid>
+                    </StackPanel>
                 </StackPanel>
 
-                <StackPanel x:Name="KeyPanel" IsVisible="False">
-                    <TextBlock Classes="label" Text="私钥文件路径"/>
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                        <TextBox x:Name="KeyPathBox" PlaceholderText="~/.ssh/id_rsa"/>
-                        <Button Grid.Column="1" Content="浏览" Click="OnBrowseKeyFile"
-                                Padding="12,6" VerticalAlignment="Bottom" Margin="0,0,0,8"/>
-                    </Grid>
+                <StackPanel x:Name="OssPanel" IsVisible="False">
+                    <TextBlock Classes="label" Text="Endpoint"/>
+                    <TextBox x:Name="EndpointBox" PlaceholderText="oss-cn-hangzhou.aliyuncs.com"/>
+
+                    <TextBlock Classes="label" Text="Bucket"/>
+                    <TextBox x:Name="BucketBox" PlaceholderText="my-bucket"/>
+
+                    <TextBlock Classes="label" Text="AccessKeyId"/>
+                    <TextBox x:Name="AccessKeyIdBox" PlaceholderText="LTAI..."/>
+
+                    <TextBlock Classes="label" Text="AccessKeySecret"/>
+                    <TextBox x:Name="AccessKeySecretBox" PlaceholderText="AccessKeySecret" PasswordChar="•"/>
+
+                    <TextBlock Text="建议使用只授权该 Bucket 的 RAM 子账号 AccessKey。"
+                               FontSize="11" Opacity="0.6" TextWrapping="Wrap" Margin="0,0,0,8"/>
                 </StackPanel>
 
                 <TextBlock Classes="label" Text="默认路径"/>

--- a/Views/Dialogs/RemoteConnectionDialog.axaml.cs
+++ b/Views/Dialogs/RemoteConnectionDialog.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Platform.Storage;
 using MacExplorer.Controls;
 using MacExplorer.Models;
 using MacExplorer.Services;
+using MacExplorer.Services.Impl;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MacExplorer.Views.Dialogs;
@@ -42,9 +43,7 @@ public partial class RemoteConnectionDialog : DialogWindow
     {
         var servers = _connectionService.GetSavedServers();
         SavedServersList.ItemsSource = servers;
-        var hasServers = servers.Count > 0;
-        if (SavedServersList.Parent is Border border)
-            border.IsVisible = hasServers;
+        SavedServersBorder.IsVisible = servers.Count > 0;
     }
 
     private void OnSavedServerSelected(object? sender, SelectionChangedEventArgs e)
@@ -79,6 +78,23 @@ public partial class RemoteConnectionDialog : DialogWindow
             PasswordRadio.IsChecked = true;
             PasswordBox.Text = server.Password;
         }
+    }
+
+    /// <summary>
+    /// The console shows a bucket as "my-bucket.oss-cn-hangzhou.aliyuncs.com", so
+    /// pasting that whole host fills in the endpoint instead of failing validation.
+    /// </summary>
+    private void OnBucketTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        var pasted = BucketBox.Text;
+        if (string.IsNullOrWhiteSpace(pasted) || !pasted.Contains('.')) return;
+
+        var endpoint = OssClientFactory.NormalizeEndpoint(pasted);
+        if (endpoint.Length == 0 || endpoint == OssClientFactory.NormalizeBucket(pasted)) return;
+
+        // Never clobber an endpoint the user typed themselves.
+        if (string.IsNullOrWhiteSpace(EndpointBox.Text))
+            EndpointBox.Text = endpoint;
     }
 
     private void OnAuthMethodChanged(object? sender, RoutedEventArgs e)
@@ -196,10 +212,12 @@ public partial class RemoteConnectionDialog : DialogWindow
                 return null;
 
             server.Protocol = RemoteProtocol.AliyunOss;
-            server.Endpoint = endpoint;
-            server.Bucket = bucket;
+            // Accept the console's copy-paste forms (bucket-prefixed host, oss:// path).
+            server.Endpoint = OssClientFactory.NormalizeEndpoint(endpoint);
+            server.Bucket = OssClientFactory.NormalizeBucket(bucket);
             server.AccessKeyId = accessKeyId;
             server.AccessKeySecret = accessKeySecret;
+            server.DefaultPath = OssClientFactory.NormalizeDefaultPath(server.DefaultPath, server.Bucket);
             return server;
         }
 

--- a/Views/Dialogs/RemoteConnectionDialog.axaml.cs
+++ b/Views/Dialogs/RemoteConnectionDialog.axaml.cs
@@ -28,6 +28,16 @@ public partial class RemoteConnectionDialog : DialogWindow
         HostBox.Focus();
     }
 
+    private bool IsOssSelected => OssRadio.IsChecked == true;
+
+    private void OnProtocolChanged(object? sender, RoutedEventArgs e)
+    {
+        var isOss = IsOssSelected;
+        SftpPanel.IsVisible = !isOss;
+        OssPanel.IsVisible = isOss;
+        (isOss ? (Control)EndpointBox : HostBox).Focus();
+    }
+
     private void RefreshSavedServers()
     {
         var servers = _connectionService.GetSavedServers();
@@ -47,6 +57,17 @@ public partial class RemoteConnectionDialog : DialogWindow
         UsernameBox.Text = server.Username;
         DefaultPathBox.Text = server.DefaultPath;
         DeleteButton.IsVisible = true;
+
+        EndpointBox.Text = server.Endpoint;
+        BucketBox.Text = server.Bucket;
+        AccessKeyIdBox.Text = server.AccessKeyId;
+        AccessKeySecretBox.Text = server.AccessKeySecret;
+
+        if (server.Protocol == RemoteProtocol.AliyunOss)
+            OssRadio.IsChecked = true;
+        else
+            SftpRadio.IsChecked = true;
+        OnProtocolChanged(this, new RoutedEventArgs());
 
         if (server.AuthMethod == RemoteAuthMethod.PrivateKey)
         {
@@ -117,7 +138,7 @@ public partial class RemoteConnectionDialog : DialogWindow
                     Spacing = 12,
                     Children =
                     {
-                        new TextBlock { Text = $"无法连接到服务器：", FontSize = 13 },
+                        new TextBlock { Text = "无法连接到服务器：", FontSize = 13 },
                         new TextBlock { Text = ex.Message, FontSize = 12, TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
                                        Foreground = new global::Avalonia.Media.SolidColorBrush(global::Avalonia.Media.Color.Parse("#FF3B30")) },
                         new Button { Content = "确定", HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right,
@@ -160,15 +181,35 @@ public partial class RemoteConnectionDialog : DialogWindow
 
     private RemoteServerInfo? BuildServerInfo()
     {
+        var server = _editingServer ?? new RemoteServerInfo();
+        server.Name = NameBox.Text?.Trim() ?? "";
+        server.DefaultPath = DefaultPathBox.Text?.Trim() ?? "/";
+
+        if (IsOssSelected)
+        {
+            var endpoint = EndpointBox.Text?.Trim();
+            var bucket = BucketBox.Text?.Trim();
+            var accessKeyId = AccessKeyIdBox.Text?.Trim();
+            var accessKeySecret = AccessKeySecretBox.Text?.Trim();
+            if (string.IsNullOrEmpty(endpoint) || string.IsNullOrEmpty(bucket)
+                || string.IsNullOrEmpty(accessKeyId) || string.IsNullOrEmpty(accessKeySecret))
+                return null;
+
+            server.Protocol = RemoteProtocol.AliyunOss;
+            server.Endpoint = endpoint;
+            server.Bucket = bucket;
+            server.AccessKeyId = accessKeyId;
+            server.AccessKeySecret = accessKeySecret;
+            return server;
+        }
+
         var host = HostBox.Text?.Trim();
         if (string.IsNullOrEmpty(host)) return null;
 
-        var server = _editingServer ?? new RemoteServerInfo();
-        server.Name = NameBox.Text?.Trim() ?? "";
+        server.Protocol = RemoteProtocol.Sftp;
         server.Host = host;
         server.Port = int.TryParse(PortBox.Text?.Trim(), out var port) ? port : 22;
         server.Username = UsernameBox.Text?.Trim() ?? "root";
-        server.DefaultPath = DefaultPathBox.Text?.Trim() ?? "/";
         server.AuthMethod = PasswordRadio.IsChecked == true ? RemoteAuthMethod.Password : RemoteAuthMethod.PrivateKey;
         server.Password = PasswordBox.Text ?? "";
         server.PrivateKeyPath = KeyPathBox.Text?.Trim() ?? "";
@@ -184,8 +225,14 @@ public partial class RemoteConnectionDialog : DialogWindow
         UsernameBox.Text = "";
         PasswordBox.Text = "";
         KeyPathBox.Text = "";
+        EndpointBox.Text = "";
+        BucketBox.Text = "";
+        AccessKeyIdBox.Text = "";
+        AccessKeySecretBox.Text = "";
         DefaultPathBox.Text = "/";
         PasswordRadio.IsChecked = true;
+        SftpRadio.IsChecked = true;
+        OnProtocolChanged(this, new RoutedEventArgs());
         DeleteButton.IsVisible = false;
     }
 }

--- a/Views/FinderSidebarView.axaml.cs
+++ b/Views/FinderSidebarView.axaml.cs
@@ -322,10 +322,11 @@ public partial class FinderSidebarView : UserControl
             : null;
         var result = await dialog.ShowDialog<RemoteServerInfo?>(window);
         if (result != null && dialog.Connected && ViewModel != null)
-        {
             await ViewModel.ConnectToServerAsync(result);
-            RefreshRemoteServersList();
-        }
+
+        // Refresh unconditionally — a server that was saved but not connected
+        // still belongs in the sidebar.
+        RefreshRemoteServersList();
     }
 
     private async void OnRemoteServerPressed(object? sender, PointerPressedEventArgs e)


### PR DESCRIPTION
## 这个 PR 做了什么

给远程管理加上阿里云 OSS 后端。原来 `IRemoteFileService` 直接返回 `SftpClient`，OSS 给不出这个对象，所以先把远程传输泛化成流抽象，再并行接入 OSS —— SFTP 的行为和代码路径保持不变。

联调过程中撞上两个仓库既有的显示 bug（SFTP 同样受影响），一并修了，见下面第二节。

## 改动

### 一、接入 OSS

**协议描述**
- `RemoteServerInfo` 新增 `RemoteProtocol` 枚举和 `Endpoint` / `Bucket` / `AccessKeyId` / `AccessKeySecret`。`Sftp = 0`，所以 `remote-servers.json` 里已有的服务器不带 `Protocol` 字段时照常反序列化成 SFTP，老配置不受影响。

**接口泛化**
- `IRemoteFileService`：`SftpClient? GetConnectedClient()` → `OpenReadAsync` / `OpenWriteAsync` / `GetFileSizeAsync`。
- `IRemoteConnectionService`：`ConnectAsync` / `GetOrConnectAsync` 不再返回 `SftpClient`（原本所有调用点都忽略了返回值），`GetClient` 改名 `GetSftpClient`，新增 `GetServer` 用来查协议。
- `CompositeFileService`、`RemoteFileEditService` 改为走流，不再认识 SFTP 类型。
- `RemotePathHelper` 抽出 SFTP / OSS 共用的路径运算。

**OSS 后端**
- `OssFileService`：OSS 是扁平 KV，目录由 `delimiter="/"` 列举的 CommonPrefixes 合成，同时跳过 OSS 控制台建目录时留下的 `foo/` 占位对象；列举按 marker 分页；删除目录批量 `DeleteObjects`（每批 1000）；改名 / 移动 / 复制用服务端 `CopyObject`，超过 1 GB 的对象走 `ResumableCopyObject`。
- OSS 没有可写流，`OpenWriteAsync` 返回的流先落临时文件，Dispose 时一次 `PutObject` 提交。
- OSS 是无状态 HTTP，没有长连接，所以“连接”= 用凭证 `DoesBucketExist` 探一次 —— 让错误的 AccessKey 在对话框里就报错，而不是等到第一次列目录才失败。
- `RemoteFileServiceRouter` 按 serverId 的协议把请求分发到 SFTP 或 OSS。

**表单填写体验**

实测第一次填就会踩坑：OSS 控制台把 bucket 展示为 `my-bucket.oss-cn-hangzhou.aliyuncs.com`，概览页又写作 `oss://my-bucket/`，照抄进来会撞上 SDK 的 bucket 命名校验（bucket 名不允许含 `.`）。

- 新增 `NormalizeBucket` / `NormalizeDefaultPath`，`NormalizeEndpoint` 也能剥掉 bucket 前缀。判据是 OSS 自身的硬约束：bucket 名不含 `.`，地域 endpoint 一律以 `oss-` 开头；CNAME 自定义域名不会被误伤。
- 保存和连接两处都做规范化，已经存下的脏配置再次连接时会被自动修正。
- Bucket 栏挪到 Endpoint 之前，粘贴完整域名时自动填充 Endpoint（仅在 Endpoint 为空时，不覆盖手填值），面板顶部说明去控制台哪里取值。

### 二、顺带修的既有 bug

- **保存后的服务器不出现在侧边栏**：`OnAddRemoteServer` 只在 `dialog.Connected` 时刷新，走「保存」+「取消」这条路存下来的服务器要等下次启动才可见。改为关闭对话框后无条件刷新。
- **对话框「已保存的服务器」区域显隐失效**：`SavedServersList.Parent is Border` 永不成立（Parent 是 `StackPanel`），那行代码从未执行过，导致列表为空时标题也一直显示。改为给 `Border` 加 `x:Name` 直接引用。

## 验证

- `dotnet build -c Debug`：通过，无新增告警（仅剩仓库原有的 Swift `CLGeocoder` deprecated 告警）。
- `dotnet test`：113 passed / 0 failed。`OssFileServiceTests` 覆盖 key 映射、prefix、endpoint / bucket / 默认路径的归一化，以及 sentinel 路径往返。
- 本机跑起来确认了配置持久化：填错形式（`global-design.oss-cn-shenzhen.aliyuncs.com` + `oss://global-design/`）经规范化后正确落盘为 `Bucket: global-design` / `DefaultPath: /`。
- 真机联调（华南深圳 `oss-cn-shenzhen.aliyuncs.com` 的真实 bucket）：**上传、下载、删除均正常**。
- **仍未实测**：改名 / 移动（`CopyObject` + `DeleteObject`）和超过 1 GB 走 `ResumableCopyObject` 的分支。

## 依赖

新增 `Aliyun.OSS.SDK.NetCore` 2.14.1（官方稳定版）。

